### PR TITLE
Nix import syntax update in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ To install the launchers on NixOS, add the following to `configuration.nix`:
 ```nix
 # configuration.nix
 let
-  aagl-gtk-on-nix = import (builtins.fetchTarball "https://github.com/ezKEa/aagl-gtk-on-nix/archive/main.tar.gz");
+  aagl-gtk-on-nix = import (builtins.fetchGit {
+    url = "https://github.com/ezKEa/aagl-gtk-on-nix.git";
+  });
 in
 {
   imports = [
@@ -72,7 +74,9 @@ You can also install the launchers using [home-manager](https://github.com/nix-c
 ```nix
 # home.nix
 let
-  aagl-gtk-on-nix = import (builtins.fetchTarball "https://github.com/ezKEa/aagl-gtk-on-nix/archive/main.tar.gz");
+  aagl-gtk-on-nix = import (builtins.fetchGit {
+    url = "https://github.com/ezKEa/aagl-gtk-on-nix.git";
+  });
 in
 {
   home.packages = [


### PR DESCRIPTION
"Pure" nix syntax, contributes towards not requiring --impure to be passed when building with flakes (since fetchTarball in pure mode requires the sha256 value to be updated constantly).