### PR TITLE
wrapAAGL: use normal curl

### DIFF
--- a/pkgs/wrapAAGL/fhsenv.nix
+++ b/pkgs/wrapAAGL/fhsenv.nix
@@ -110,7 +110,7 @@ in buildFHSEnv rec {
     xorg.libSM
     xorg.libICE
     gnome2.GConf
-    curlWithGnuTls
+    curl
     nspr
     nss
     cups


### PR DESCRIPTION
This replicates the change from https://github.com/NixOS/nixpkgs/pull/340710

But also, all of wrapAAGL is a huge mess with Steam-specific hacks copied from nixpkgs, which should really be cleaned up/removed.