### PR TITLE
Adding the missing pkgs to waves.nix

### DIFF
--- a/module/waves.nix
+++ b/module/waves.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 with lib; let


### PR DESCRIPTION
Fixing the `error: undefined variable 'pkgs'` complaint from Nix.