### PR TITLE
add extraPkgs and extraLibraries to wrapAAGL

### DIFF
--- a/pkgs/wrapAAGL/default.nix
+++ b/pkgs/wrapAAGL/default.nix
@@ -16,6 +16,8 @@
   libwebp,
   gamescope,
   unzip,
+  extraPkgs ? pkgs: [ ], # extra packages to add to targetPkgs
+  extraLibraries ? pkgs: [ ], # extra packages to add to multiPkgs
 }:
 {
   unwrapped,
@@ -46,7 +48,9 @@ let
         xdelta
         unzip
         libwebp
-      ];
+      ] ++ (
+        extraPkgs _p
+      );
       extraLibraries = _p: [
         libunwind
       ] ++ ( with gst_all_1; [
@@ -56,7 +60,9 @@ let
         gst-vaapi
         gst-plugins-bad
         gst-plugins-good
-      ]);
+      ]) ++ (
+        extraLibraries _p
+      );
       extraProfile = ''
         export PATH=${fakePkExec}/bin:$PATH
       '';


### PR DESCRIPTION
add the ability to add extra packages or libraries to FHSEnv made by wrapAAGL
so the following snippet will be possible:
```nix
{
  home.packages = with aagl.pkgs; [
    (honkers-railway-launcher.override (prev: prev // {
      wrapAAGL = wrapAAGL.override (a: a // {
        extraPkgs = (_p: [ pkgs-unstable.umu-launcher-unwrapped ] );
        #extraLibraries = (_p: [ ]);
      });
    }))
  ];
}
```