### PR TITLE
treewide: remove useFetchCargoVendor

### DIFF
--- a/pkgs/anime-game-launcher/unwrapped.nix
+++ b/pkgs/anime-game-launcher/unwrapped.nix
@@ -35,7 +35,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-kqlbhObHmRTiNxXOUhTXB1SEc0zvuzpREJ26h/YM82E=";
 
     nativeBuildInputs = [

--- a/pkgs/anime-games-launcher/unwrapped.nix
+++ b/pkgs/anime-games-launcher/unwrapped.nix
@@ -33,7 +33,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-mTt3cCK0dK00r6H6UFTbFpkvi09MSgSYiz9xV8Msim4=";
 
     nativeBuildInputs = [

--- a/pkgs/honkers-launcher/unwrapped.nix
+++ b/pkgs/honkers-launcher/unwrapped.nix
@@ -34,7 +34,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-+161LSelvBxfq32cENcjikMXv3xt1SOcSz2Tx5Izbh4=";
 
     nativeBuildInputs = [

--- a/pkgs/honkers-railway-launcher/unwrapped.nix
+++ b/pkgs/honkers-railway-launcher/unwrapped.nix
@@ -34,7 +34,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-M7utTWKnGVuupRjcSRi7MYfipUB0gkXWsTf4+Zh3w8A=";
 
     nativeBuildInputs = [

--- a/pkgs/sleepy-launcher/unwrapped.nix
+++ b/pkgs/sleepy-launcher/unwrapped.nix
@@ -34,7 +34,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-YgN8PoNnm+4/V6VhtCJhiYcYL4nwRP94OifjuYZrWKo=";
 
     nativeBuildInputs = [

--- a/pkgs/wavey-launcher/unwrapped.nix
+++ b/pkgs/wavey-launcher/unwrapped.nix
@@ -34,7 +34,6 @@ with lib;
       cp ${customIcon} assets/images/icon.png
     '';
 
-    useFetchCargoVendor = true;
     cargoHash = "sha256-rz/zLXV/YsgoSogzShF0MHY9hXvCYvP1indRqeWT/lc=";
 
     nativeBuildInputs = [


### PR DESCRIPTION
It's the default on all supported nixpkgs versions, and warns on unstable.