### PR TITLE
Flake: keep module.nix and overlay.nix flake independent

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -1,4 +1,4 @@
-flake: {
+{
   imports = [
     ./aagl.nix
     ./agl.nix
@@ -8,9 +8,5 @@ flake: {
     ./sleepy.nix
     ./hosts.nix
     ./version.nix
-  ];
-
-  nixpkgs.overlays = [
-    flake.outputs.overlays.default
   ];
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,8 +1,9 @@
-flake:
+{ rust-overlay }:
+
 final: prev:
 let
   rust-bin = (prev.appendOverlays [
-    (import flake.inputs.rust-overlay)
+    (import rust-overlay)
   ]).rust-bin;
 
   mkLauncher = launcher: final.callPackage ./pkgs/${launcher} {


### PR DESCRIPTION
Heyya luxxy! this pr does the following things:
- removal of flake dependency on overlay.nix
- removal of flake dependency from modules/default.nix
- re-orchestration of the flake.nix to perform the required additions to overlay and nixosModule

### Motivation
The recent changes to the module and overlay.nix  has broken what was  previously easily consumable non flake expressions. The  changes in this pr ensure that the module and overlay can be consumed independent of flakes by separating out the the flake requirement atop both those files. In compensation, the flake.nix has been modified making the default overlay via `lib.composeExtention` of rust-overlay and overlay.nix and cleanly applying the the overlay within the flake's nixosModules.default expression.

### Tests
- [x] packages evaluate as expected
- [x] nixosModules evalutes as expected on flake based configurations
- [x] module.nix and overlay.nix is consumable on non flake configurations