### PR TITLE
fix: remove deprecated `lib.mdDoc`

### DIFF
--- a/module/aagl.nix
+++ b/module/aagl.nix
@@ -15,14 +15,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable anime-game-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.anime-game-launcher;
-      description = lib.mdDoc ''
+      description = ''
         anime-game-launcher package to use.
       '';
     };

--- a/module/agl.nix
+++ b/module/agl.nix
@@ -15,14 +15,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable anime-games-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.anime-games-launcher;
-      description = lib.mdDoc ''
+      description = ''
         anime-games-launcher package to use.
       '';
     };

--- a/module/hl.nix
+++ b/module/hl.nix
@@ -11,14 +11,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable honkers-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.honkers-launcher;
-      description = lib.mdDoc ''
+      description = ''
         honkers-launcher package to use.
       '';
     };

--- a/module/hosts.nix
+++ b/module/hosts.nix
@@ -10,7 +10,7 @@ in {
     block = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to block miHoYo telemetry servers.
       '';
     };

--- a/module/hrl.nix
+++ b/module/hrl.nix
@@ -15,14 +15,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable honkers-railway-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.honkers-railway-launcher;
-      description = lib.mdDoc ''
+      description = ''
         honkers-railway-launcher package to use.
       '';
     };

--- a/module/sleepy.nix
+++ b/module/sleepy.nix
@@ -12,14 +12,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable sleepy-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.sleepy-launcher;
-      description = lib.mdDoc ''
+      description = ''
         sleepy-launcher package to use.
       '';
     };

--- a/module/waves.nix
+++ b/module/waves.nix
@@ -11,14 +11,14 @@ in {
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable wavey-launcher.
       '';
     };
     package = mkOption {
       type = types.package;
       default = pkgs.wavey-launcher;
-      description = lib.mdDoc ''
+      description = ''
         wavey-launcher package to use.
       '';
     };


### PR DESCRIPTION
See the following for more info:
- tracking issue: https://github.com/NixOS/nixpkgs/issues/300735
- changes in the manual: https://github.com/NixOS/nixpkgs/pull/237557
- removal in nixpkgs: https://github.com/NixOS/nixpkgs/pull/303841
- PR documenting timeline for removal: https://github.com/NixOS/nixpkgs/pull/304277

From the PR in that last link:
> lib.mdDoc will be removed from nixpkgs in 24.11. Option descriptions
> are now in Markdown by default; you can remove any remaining uses of
> lib.mdDoc.

Fixes: https://github.com/ezKEa/aagl-gtk-on-nix/issues/237